### PR TITLE
Add Mint installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Generate code by using a stencil template and a json or yaml data source
 
+## Instalation
+
+### Using [Mint](https://github.com/yonaskolb/mint):
+```
+$ mint install alephao/Stencly
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
Since there are no instructions on how to install the library, I thought it would be interesting to add a quick how-to install via Mint.